### PR TITLE
fix: Hapus parameter URL saat redirect untuk pengguna yang tidak terotorisasi

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,15 +47,11 @@ export default auth((req) => {
 
   if (isLoggedIn) {
     if (isAdministratorRoute && !isAdministrator) {
-      return Response.redirect(
-        new URL('/signin?message=Not Authorized', nextUrl),
-      )
+      return Response.redirect(new URL('/signin', nextUrl))
     }
 
     if (isOperatorRoute && !isOperator) {
-      return Response.redirect(
-        new URL(`/signin?message=Not Authorized`, nextUrl),
-      )
+      return Response.redirect(new URL(`/signin`, nextUrl))
     }
 
     return


### PR DESCRIPTION
Hapus parameter URL saat redirect untuk pengguna yang tidak terotorisasi